### PR TITLE
corym targeting settings

### DIFF
--- a/waypoints/Venore East Coryms (EK).xbst
+++ b/waypoints/Venore East Coryms (EK).xbst
@@ -58,8 +58,9 @@
 </panel>
 <panel name="Targeting">
 	<control name="TargetingList">
-		<item type="Corym Vanguard" chs="1" max="100" min="0" prio="2" prox="7" count="1"/>
-		<item type="Corym Charlatan, Corym Skirmisher, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
+		<item type="Corym Skirmisher" chs="0" max="100" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Vanguard" chs="1" max="50" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Skirmisher, Corym Charlatan, Corym Vanguard, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
 		<item type="*" chs="0" max="100" min="0" prio="10" prox="7" count="1"/>
 	</control>
 </panel>

--- a/waypoints/Venore North Coryms (EK).xbst
+++ b/waypoints/Venore North Coryms (EK).xbst
@@ -62,7 +62,7 @@
 		<item type="Corym Vanguard" chs="1" max="50" min="0" prio="2" prox="2" count="1"/>
 		<item type="Corym Skirmisher, Corym Charlatan, Corym Vanguard, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
 		<item type="*" chs="0" max="100" min="0" prio="10" prox="7" count="1"/>
-	<control>
+	</control>
 </panel>
 <panel name="Walker">
 	<control name="WaypointList">

--- a/waypoints/Venore North Coryms (EK).xbst
+++ b/waypoints/Venore North Coryms (EK).xbst
@@ -58,10 +58,10 @@
 </panel>
 <panel name="Targeting">
 	<control name="TargetingList">
-		<item type="Corym Vanguard" chs="1" max="100" min="0" prio="2" prox="7" count="1"/>
-		<item type="Corym Charlatan, Corym Skirmisher, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
+		<item type="Corym Skirmisher" chs="0" max="100" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Vanguard" chs="1" max="50" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Skirmisher, Corym Charlatan, Corym Vanguard, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
 		<item type="*" chs="0" max="100" min="0" prio="10" prox="7" count="1"/>
-	</control>
 </panel>
 <panel name="Walker">
 	<control name="WaypointList">

--- a/waypoints/Venore North Coryms (EK).xbst
+++ b/waypoints/Venore North Coryms (EK).xbst
@@ -62,6 +62,7 @@
 		<item type="Corym Vanguard" chs="1" max="50" min="0" prio="2" prox="2" count="1"/>
 		<item type="Corym Skirmisher, Corym Charlatan, Corym Vanguard, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
 		<item type="*" chs="0" max="100" min="0" prio="10" prox="7" count="1"/>
+	<control>
 </panel>
 <panel name="Walker">
 	<control name="WaypointList">

--- a/waypoints/Venore South Coryms (EK).xbst
+++ b/waypoints/Venore South Coryms (EK).xbst
@@ -58,8 +58,9 @@
 </panel>
 <panel name="Targeting">
 	<control name="TargetingList">
-		<item type="Corym Vanguard" chs="1" max="100" min="0" prio="2" prox="7" count="1"/>
-		<item type="Corym Charlatan, Corym Skirmisher, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
+		<item type="Corym Skirmisher" chs="0" max="100" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Vanguard" chs="1" max="50" min="0" prio="2" prox="2" count="1"/>
+		<item type="Corym Skirmisher, Corym Charlatan, Corym Vanguard, Little Corym Charlatan" chs="0" max="100" min="0" prio="1" prox="7" count="1"/>
 		<item type="*" chs="0" max="100" min="0" prio="10" prox="7" count="1"/>
 	</control>
 </panel>


### PR DESCRIPTION
Rationale:
With knight scripts all melee creatures should always have the same priority unless they're close.

Skirmishers do almost the same damage as vanguards but have half the hp. They should have the highest priority when they're close.

However, if a Vanguard is already hurt their priority is the same as a Skirmisher.

Finally, since Vanguards run at low hp "close" is considered 2 sqm instead of 1 or we risk dropping them when they flee.
